### PR TITLE
Small checker for obsidian iso's

### DIFF
--- a/obsidian-wizard.py
+++ b/obsidian-wizard.py
@@ -102,7 +102,7 @@ def _detect_distro():
 
 DISTRO_ID, DISTRO_ID_LIKE = _detect_distro()
 IS_ARCH_LIKE   = "arch"   in DISTRO_ID or "arch"   in DISTRO_ID_LIKE
-IS_GENTOO_LIKE = "gentoo" in DISTRO_ID or "gentoo" in DISTRO_ID_LIKE or DISTRO_ID == "obsidian"
+IS_GENTOO_LIKE = "gentoo" in DISTRO_ID or "gentoo" in DISTRO_ID_LIKE
 
 # Pick the right template for the running distro
 DEFAULT_MKOBSFS_CONTENT = (
@@ -110,8 +110,7 @@ DEFAULT_MKOBSFS_CONTENT = (
 )
 
 # True when running from a live ISO/USB (system.sfs is the live image)
-IS_ARCHISO_REAL = os.path.isfile("/etc/system.sfs")
-IS_ARCHISO = True  # kept for compatibility
+IS_ARCHISO = os.path.isfile("/etc/system.sfs")
 
 OBSIDIANCTL_PATH = shutil.which("obsidianctl") or "/usr/local/sbin/obsidianctl"
 
@@ -403,7 +402,7 @@ def select_system_image(action_type="install"):
         pass
 
     options = ["Create New Config"]
-    if IS_ARCHISO_REAL:
+    if IS_ARCHISO:
         options.append("Default System Image")
 
     if mkobsfs_files:
@@ -1104,15 +1103,6 @@ def main():
             "Drop to Terminal",
             "Reboot System",
         ]
-        if not IS_ARCHISO:
-            main_options.extend(
-                [
-                    "Update System",
-                    "Switch Slot and Reboot (temporary)",
-                    "Switch Slot and Reboot (permanent)",
-                    "Sync slots",
-                ]
-            )
         choice = selection_menu(
             "ObsidianOS Wizard" if IS_GENTOO_LIKE else "ARbs - the ARch image Based inStaller",
             main_options,
@@ -1122,21 +1112,6 @@ def main():
             installation_flow("Install")
         elif choice == "Repair ObsidianOS":
             update_flow("Repair")
-        elif choice == "Update System":
-            update_flow("Update")
-        elif choice == "Switch Slot and Reboot (temporary)":
-            run_command(
-                f"{OBSIDIANCTL_PATH} switch-once {NEXT_SLOT}", "Switching slot..."
-            )
-            reboot_system()
-            print_centered("Please reboot to switch slots.")
-        elif choice == "Switch Slot and Reboot (permanent)":
-            run_command(f"{OBSIDIANCTL_PATH} switch {NEXT_SLOT}", "Switching slot...")
-            reboot_system()
-            print_centered("Please reboot to switch slots.")
-        elif choice == "Sync slots":
-            run_command(f"{OBSIDIANCTL_PATH} sync {NEXT_SLOT}", "Syncing slots...")
-            print_centered("Slots synced.")
         elif choice == "Drop to Terminal":
             clear_screen()
             print_centered("Dropping to terminal...", Colors.BRIGHT_GREEN)
@@ -1155,8 +1130,7 @@ if __name__ == "__main__":
     # Arch live ISOs use a cowspace overlay that needs expanding.
     # Gentoo live ISOs use dracut dmsquash-live with a tmpfs overlay — no cowspace.
     if (
-        IS_ARCHISO
-        and IS_ARCH_LIKE
+        IS_ARCH_LIKE
         and os.path.exists("/run/archiso")
         and not os.path.isfile("/etc/obsidian-wizard-resized")
     ):

--- a/obsidian-wizard.py
+++ b/obsidian-wizard.py
@@ -104,7 +104,7 @@ def _detect_distro():
     d_name_first = name.split()[0] if name else ""
 
     # If on ObsidianOS ISO, detect it via the package manager
-    if "obsidian" in d_id or "obsidian" in d_name_first:
+    if "obsidian" in d_id or "obsidianos" in d_name_first:
         if shutil.which("pacman"):
             d_id = "arch"
         elif shutil.which("emerge"):

--- a/obsidian-wizard.py
+++ b/obsidian-wizard.py
@@ -656,8 +656,16 @@ def is_laptop():
 
 
 def start_iwd_service():
-    """Start iwd (Arch) or ensure NetworkManager is running (Gentoo/others)."""
-    if IS_ARCH_LIKE:
+    """Start iwd (systemd) or NetworkManager (OpenRC or no iwd)."""
+    # On OpenRC, always use NetworkManager via rc-service
+    if shutil.which("rc-service"):
+        try:
+            subprocess.run(["rc-service", "NetworkManager", "start"], check=False)
+            time.sleep(2)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+    elif shutil.which("iwd") or shutil.which("iwctl"):
         try:
             subprocess.run(["systemctl", "start", "iwd"], check=True)
             time.sleep(2)
@@ -691,7 +699,7 @@ def _get_wifi_interface():
 
 def get_wifi_networks():
     """Scan and return networks. Uses iwctl on Arch, nmcli on Gentoo/others."""
-    if IS_ARCH_LIKE and shutil.which("iwctl"):
+    if shutil.which("iwctl") and shutil.which("iwd") and not shutil.which("rc-service"):
         try:
             iface = "wlan0"
             subprocess.run(["iwctl", "station", iface, "scan"],
@@ -743,7 +751,7 @@ def get_wifi_networks():
 
 def connect_wifi(ssid, password=None):
     """Connect to WiFi. Uses iwctl on Arch, nmcli on Gentoo/others."""
-    if IS_ARCH_LIKE and shutil.which("iwctl"):
+    if shutil.which("iwctl") and shutil.which("iwd") and not shutil.which("rc-service"):
         try:
             if password:
                 result = subprocess.run(
@@ -783,9 +791,9 @@ def wifi_configuration_menu():
         get_key()
         return False
 
-    print_centered("Starting iwd service...", Colors.BRIGHT_CYAN)
+    print_centered("Starting network service...", Colors.BRIGHT_CYAN)
     if not start_iwd_service():
-        print_centered("Failed to start iwd service", Colors.FAIL)
+        print_centered("Failed to start network service", Colors.FAIL)
         print("\n" * 2)
         print_centered("Press any key to continue...", Colors.DIM)
         get_key()
@@ -813,17 +821,51 @@ def wifi_configuration_menu():
         return wifi_configuration_menu()
 
     ssid = choice.split(" (")[0]
-    security = choice.split(" (")[1].rstrip(")")
+    security = choice.split(" (")[1].rstrip(")") if " (" in choice else "Open"
 
     password = None
-    if security == "PSK":
-        clear_screen()
-        draw_header()
-        print("\n" * 2)
-        print_centered(f"Enter password for {ssid}", Colors.BRIGHT_WHITE + Colors.BOLD)
-        print_centered("Password will not be shown as you type", Colors.DIM)
-        print("\n")
-        password = input("Password: ")
+    # Always show password prompt - press Enter to skip for open networks
+    clear_screen()
+    draw_header()
+    print("\n" * 2)
+    print_centered(f"Enter password for {ssid}", Colors.BRIGHT_WHITE + Colors.BOLD)
+    if security.lower() == "open":
+        print_centered("Open network - press Enter to connect without a password", Colors.DIM)
+    else:
+        print_centered(f"Security: {security} - press Enter to skip if no password needed", Colors.DIM)
+    print_centered("Press Tab to toggle show/hide password", Colors.DIM)
+    print("\n")
+    import sys as _sys
+    import tty as _tty
+    import termios as _termios
+    _show_password = False
+    _pwd_chars = []
+    _fd = _sys.stdin.fileno()
+    _old_settings = _termios.tcgetattr(_fd)
+    try:
+        _tty.setraw(_fd)
+        while True:
+            _display = "".join(_pwd_chars) if _show_password else "*" * len(_pwd_chars)
+            _label = "visible" if _show_password else "hidden"
+            _sys.stdout.write(f"\r\033[KPassword ({_label}): {_display}")
+            _sys.stdout.flush()
+            ch = _sys.stdin.read(1)
+            if ch in ("\r", "\n"):
+                _sys.stdout.write("\n")
+                break
+            elif ch == "\t":
+                _show_password = not _show_password
+            elif ch in ("\x7f", "\x08"):
+                if _pwd_chars:
+                    _pwd_chars.pop()
+            elif ch == "\x03":
+                _termios.tcsetattr(_fd, _termios.TCSADRAIN, _old_settings)
+                raise KeyboardInterrupt
+            elif ord(ch) >= 32:
+                _pwd_chars.append(ch)
+    finally:
+        _termios.tcsetattr(_fd, _termios.TCSADRAIN, _old_settings)
+    password = "".join(_pwd_chars) if _pwd_chars else None
 
     clear_screen()
     print_centered("Connecting to WiFi...", Colors.BRIGHT_CYAN)

--- a/obsidian-wizard.py
+++ b/obsidian-wizard.py
@@ -86,7 +86,6 @@ DEFAULT_PARTITION_SIZES = {
 }
 
 def _detect_distro():
-    """Return (distro_id, distro_id_like) from /etc/os-release."""
     vals = {}
     for path in ("/etc/os-release", "/usr/lib/os-release"):
         try:
@@ -656,8 +655,6 @@ def is_laptop():
 
 
 def start_iwd_service():
-    """Start iwd (systemd) or NetworkManager (OpenRC or no iwd)."""
-    # On OpenRC, always use NetworkManager via rc-service
     if shutil.which("rc-service"):
         try:
             subprocess.run(["rc-service", "NetworkManager", "start"], check=False)
@@ -682,7 +679,6 @@ def start_iwd_service():
 
 
 def _get_wifi_interface():
-    """Return the first wireless interface name."""
     try:
         result = subprocess.run(
             ["nmcli", "-t", "-f", "DEVICE,TYPE", "device"],
@@ -698,7 +694,6 @@ def _get_wifi_interface():
 
 
 def get_wifi_networks():
-    """Scan and return networks. Uses iwctl on Arch, nmcli on Gentoo/others."""
     if shutil.which("iwctl") and shutil.which("iwd") and not shutil.which("rc-service"):
         try:
             iface = "wlan0"
@@ -723,7 +718,6 @@ def get_wifi_networks():
             pass
         return []
     else:
-        # NetworkManager path (Gentoo, Debian, etc.)
         try:
             iface = _get_wifi_interface()
             subprocess.run(["nmcli", "device", "wifi", "rescan"],
@@ -750,7 +744,6 @@ def get_wifi_networks():
 
 
 def connect_wifi(ssid, password=None):
-    """Connect to WiFi. Uses iwctl on Arch, nmcli on Gentoo/others."""
     if shutil.which("iwctl") and shutil.which("iwd") and not shutil.which("rc-service"):
         try:
             if password:

--- a/obsidian-wizard.py
+++ b/obsidian-wizard.py
@@ -98,16 +98,38 @@ def _detect_distro():
             break
         except FileNotFoundError:
             continue
-    return vals.get("ID", "").lower(), vals.get("ID_LIKE", "").lower()
 
-DISTRO_ID, DISTRO_ID_LIKE = _detect_distro()
-IS_ARCH_LIKE   = "arch"   in DISTRO_ID or "arch"   in DISTRO_ID_LIKE
-IS_GENTOO_LIKE = "gentoo" in DISTRO_ID or "gentoo" in DISTRO_ID_LIKE
+    d_id = vals.get("ID", "").lower()
+    name = vals.get("NAME", "").lower()
+    d_name_first = name.split()[0] if name else ""
 
-# Pick the right template for the running distro
-DEFAULT_MKOBSFS_CONTENT = (
-    DEFAULT_MKOBSFS_CONTENT_GENTOO if IS_GENTOO_LIKE else DEFAULT_MKOBSFS_CONTENT_ARCH
-)
+    # If on ObsidianOS ISO, detect it via the package manager
+    if "obsidian" in d_id or "obsidian" in d_name_first:
+        if shutil.which("pacman"):
+            d_id = "arch"
+        elif shutil.which("emerge"):
+            d_id = "gentoo"
+        elif shutil.which("xbps-install"):
+            d_id = "void"
+        elif shutil.which("apk"):
+            d_id = "alpine"
+        elif shutil.which("apt-get") or shutil.which("apt") or shutil.which("dpkg"):
+            d_id = "debian"
+    return d_id, d_name_first
+    
+DISTROS = ("arch", "gentoo", "void", "alpine", "debian")
+DISTRO_ID, DISTRO_NAME = _detect_distro()
+
+MATCHED_DISTRO = DISTROS[0]
+for distro in DISTROS:
+    is_match = (distro == DISTRO_ID)
+    globals()[f"IS_{distro.upper()}_LIKE"] = is_match
+
+    if is_match:
+        MATCHED_DISTRO = distro
+
+TEMPLATE_CONTENT = f"DEFAULT_MKOBSFS_CONTENT_{MATCHED_DISTRO.upper()}"
+DEFAULT_MKOBSFS_CONTENT = globals().get(TEMPLATE_CONTENT, DEFAULT_MKOBSFS_CONTENT_ARCH)
 
 # True when running from a live ISO/USB (system.sfs is the live image)
 IS_ARCHISO = os.path.isfile("/etc/system.sfs")

--- a/obsidian-wizard.py
+++ b/obsidian-wizard.py
@@ -27,7 +27,8 @@ class Colors:
     BRIGHT_YELLOW = "\033[93m"
 
 
-DEFAULT_MKOBSFS_CONTENT = """
+# Arch-based config template
+DEFAULT_MKOBSFS_CONTENT_ARCH = """
 :<<:
 Packages can be programs or parts of your system.
 $PACKAGES can be thought of as a mega-package in this situation that has everything needed for boot..
@@ -61,6 +62,22 @@ ADMIN_DOTFILES=""
 ADMIN_DOTFILES_TYPE=""
 """
 
+DEFAULT_MKOBSFS_CONTENT_GENTOO = """
+GENTOO_INIT="systemd"
+GENTOO_PREFER_BINHOST="true"
+ACCEPT_LICENSE="*"
+ENABLE_AMDGPU="true"
+ENABLE_NVIDIA=""
+# Add Portage packages below. For a desktop add x11-wm/openbox or kde-plasma/plasma-meta etc.
+PACKAGES="$PACKAGES"
+TIMEZONE=""
+HOSTNAME="obsidian-gentoo"
+SERVICES="NetworkManager"
+ADMIN_USER="user"
+ADMIN_DOTFILES=""
+ADMIN_DOTFILES_TYPE=""
+"""
+
 DEFAULT_PARTITION_SIZES = {
     "esp_size": "512M",
     "rootfs_size": "10G",
@@ -68,13 +85,36 @@ DEFAULT_PARTITION_SIZES = {
     "var_size": "5G",
 }
 
-IS_ARCHISO_REAL = os.path.isfile("/etc/system.sfs")
-IS_ARCHISO = True
-OBSIDIANCTL_PATH = (
-    "obsidianctl"
-    if IS_ARCHISO
-    else (shutil.which("obsidianctl") or "/tmp/obsidianctl/obsidianctl")
+def _detect_distro():
+    """Return (distro_id, distro_id_like) from /etc/os-release."""
+    vals = {}
+    for path in ("/etc/os-release", "/usr/lib/os-release"):
+        try:
+            with open(path) as f:
+                for line in f:
+                    line = line.strip()
+                    if "=" in line and not line.startswith("#"):
+                        k, _, v = line.partition("=")
+                        vals[k.strip()] = v.strip().strip('"')
+            break
+        except FileNotFoundError:
+            continue
+    return vals.get("ID", "").lower(), vals.get("ID_LIKE", "").lower()
+
+DISTRO_ID, DISTRO_ID_LIKE = _detect_distro()
+IS_ARCH_LIKE   = "arch"   in DISTRO_ID or "arch"   in DISTRO_ID_LIKE
+IS_GENTOO_LIKE = "gentoo" in DISTRO_ID or "gentoo" in DISTRO_ID_LIKE or DISTRO_ID == "obsidian"
+
+# Pick the right template for the running distro
+DEFAULT_MKOBSFS_CONTENT = (
+    DEFAULT_MKOBSFS_CONTENT_GENTOO if IS_GENTOO_LIKE else DEFAULT_MKOBSFS_CONTENT_ARCH
 )
+
+# True when running from a live ISO/USB (system.sfs is the live image)
+IS_ARCHISO_REAL = os.path.isfile("/etc/system.sfs")
+IS_ARCHISO = True  # kept for compatibility
+
+OBSIDIANCTL_PATH = shutil.which("obsidianctl") or "/usr/local/sbin/obsidianctl"
 
 
 def get_current_slots():
@@ -358,7 +398,7 @@ def select_system_image(action_type="install"):
     current_dir_files = []
     try:
         for f in os.listdir("."):
-            if f.endswith(".mkobsfs") or f.endswith(".sfs"):
+            if f.endswith(".mkobsfs") or f.endswith(".mkobsfs-gentoo") or f.endswith(".sfs"):
                 current_dir_files.append(f"[Current Dir] {f}")
     except:
         pass
@@ -391,6 +431,7 @@ def select_system_image(action_type="install"):
         if choice is None:
             return None
 
+        extension = "mkobsfs-gentoo" if IS_GENTOO_LIKE else "mkobsfs"
         if choice.startswith("Default System Image"):
             if confirm(
                 "Use default system image (/etc/system.sfs)?",
@@ -402,7 +443,7 @@ def select_system_image(action_type="install"):
             ):
                 return "/etc/system.sfs"
         elif choice.startswith("Create"):
-            config_file_path = os.path.expanduser("~/config.mkobsfs")
+            config_file_path = os.path.expanduser(f"~/config.{extension}")
             with open(config_file_path, "w") as f:
                 f.write(DEFAULT_MKOBSFS_CONTENT)
             clear_screen()
@@ -615,64 +656,117 @@ def is_laptop():
 
 
 def start_iwd_service():
+    """Start iwd (Arch) or ensure NetworkManager is running (Gentoo/others)."""
+    if IS_ARCH_LIKE:
+        try:
+            subprocess.run(["systemctl", "start", "iwd"], check=True)
+            time.sleep(2)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+    else:
+        try:
+            subprocess.run(["systemctl", "start", "NetworkManager"], check=True)
+            time.sleep(2)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+
+def _get_wifi_interface():
+    """Return the first wireless interface name."""
     try:
-        subprocess.run(["systemctl", "start", "iwd"], check=True)
-        time.sleep(2)
-        return True
-    except subprocess.CalledProcessError:
-        return False
+        result = subprocess.run(
+            ["nmcli", "-t", "-f", "DEVICE,TYPE", "device"],
+            capture_output=True, text=True, timeout=5
+        )
+        for line in result.stdout.splitlines():
+            dev, _, dtype = line.partition(":")
+            if dtype.strip() == "wifi":
+                return dev.strip()
+    except Exception:
+        pass
+    return "wlan0"
 
 
 def get_wifi_networks():
-    try:
-        result = subprocess.run(
-            ["iwctl", "station", "wlan0", "scan"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        time.sleep(3)
-        result = subprocess.run(
-            ["iwctl", "station", "wlan0", "get-networks"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        if result.returncode == 0:
+    """Scan and return networks. Uses iwctl on Arch, nmcli on Gentoo/others."""
+    if IS_ARCH_LIKE and shutil.which("iwctl"):
+        try:
+            iface = "wlan0"
+            subprocess.run(["iwctl", "station", iface, "scan"],
+                           capture_output=True, text=True, timeout=10)
+            time.sleep(3)
+            result = subprocess.run(
+                ["iwctl", "station", iface, "get-networks"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode == 0:
+                networks = []
+                for line in result.stdout.split("\n")[4:]:
+                    if line.strip() and ("PSK" in line or "Open" in line):
+                        parts = line.split()
+                        if parts:
+                            ssid = parts[0]
+                            security = "PSK" if "PSK" in line else "Open"
+                            networks.append(f"{ssid} ({security})")
+                return networks
+        except Exception:
+            pass
+        return []
+    else:
+        # NetworkManager path (Gentoo, Debian, etc.)
+        try:
+            iface = _get_wifi_interface()
+            subprocess.run(["nmcli", "device", "wifi", "rescan"],
+                           capture_output=True, timeout=8)
+            time.sleep(3)
+            result = subprocess.run(
+                ["nmcli", "-t", "-f", "SSID,SECURITY", "device", "wifi", "list"],
+                capture_output=True, text=True, timeout=10,
+            )
             networks = []
-            lines = result.stdout.split("\n")
-            for line in lines[4:]:
-                if line.strip() and "PSK" in line or "Open" in line:
-                    parts = line.split()
-                    if parts:
-                        ssid = parts[0]
-                        security = "PSK" if "PSK" in line else "Open"
+            seen = set()
+            for line in result.stdout.splitlines():
+                parts = line.split(":")
+                if len(parts) >= 2:
+                    ssid = parts[0].strip()
+                    security = parts[1].strip() or "Open"
+                    if ssid and ssid not in seen:
+                        seen.add(ssid)
                         networks.append(f"{ssid} ({security})")
             return networks
-    except:
-        pass
-    return []
+        except Exception:
+            pass
+        return []
 
 
 def connect_wifi(ssid, password=None):
-    try:
-        if password:
-            result = subprocess.run(
-                ["iwctl", "--password", password, "station", "wlan0", "connect", ssid],
-                capture_output=True,
-                text=True,
-                timeout=15,
-            )
-        else:
-            result = subprocess.run(
-                ["iwctl", "station", "wlan0", "connect", ssid],
-                capture_output=True,
-                text=True,
-                timeout=15,
-            )
-        return result.returncode == 0
-    except:
-        return False
+    """Connect to WiFi. Uses iwctl on Arch, nmcli on Gentoo/others."""
+    if IS_ARCH_LIKE and shutil.which("iwctl"):
+        try:
+            if password:
+                result = subprocess.run(
+                    ["iwctl", "--password", password, "station", "wlan0", "connect", ssid],
+                    capture_output=True, text=True, timeout=15,
+                )
+            else:
+                result = subprocess.run(
+                    ["iwctl", "station", "wlan0", "connect", ssid],
+                    capture_output=True, text=True, timeout=15,
+                )
+            return result.returncode == 0
+        except Exception:
+            return False
+    else:
+        try:
+            cmd = ["nmcli", "device", "wifi", "connect", ssid]
+            if password:
+                cmd += ["password", password]
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+            return result.returncode == 0
+        except Exception:
+            return False
 
 
 def wifi_configuration_menu():
@@ -985,7 +1079,7 @@ def main():
                 ]
             )
         choice = selection_menu(
-            "ARbs - the ARch image Based inStaller",
+            "ObsidianOS Wizard" if IS_GENTOO_LIKE else "ARbs - the ARch image Based inStaller",
             main_options,
             "What would you like to do?",
         )
@@ -1023,8 +1117,11 @@ def main():
 
 
 if __name__ == "__main__":
+    # Arch live ISOs use a cowspace overlay that needs expanding.
+    # Gentoo live ISOs use dracut dmsquash-live with a tmpfs overlay — no cowspace.
     if (
         IS_ARCHISO
+        and IS_ARCH_LIKE
         and os.path.exists("/run/archiso")
         and not os.path.isfile("/etc/obsidian-wizard-resized")
     ):
@@ -1049,6 +1146,28 @@ if __name__ == "__main__":
             print_centered("REBOOTING...", Colors.FAIL + Colors.BOLD)
             time.sleep(5)
             run_command("sudo reboot", f"Rebooting system due to error {str(e)}...")
+    # Gentoo live ISOs write the stage tarball to /tmp, so expand it to use
+    # most of available RAM to avoid "no space left on device" errors.
+    if IS_GENTOO_LIKE and not os.path.isfile("/etc/obsidian-wizard-resized"):
+        try:
+            clear_screen()
+            run_command(
+                "mount -o remount,size=75% /tmp", "Resizing /tmp tmpfs..."
+            )
+            open("/etc/obsidian-wizard-resized", "w").close()
+        except (KeyboardInterrupt, SystemExit):
+            clear_screen()
+            print_centered(
+                "Resizing aborted. It is probably a good idea to restart your computer.",
+                Colors.WARNING,
+            )
+            time.sleep(0.5)
+        except Exception as e:
+            clear_screen()
+            print_centered("CRITICAL ERROR", Colors.FAIL + Colors.BOLD)
+            print_centered(str(e), Colors.FAIL)
+            print_centered("Please report this bug", Colors.DIM)
+            time.sleep(2)
     try:
         main()
     except (KeyboardInterrupt, SystemExit):


### PR DESCRIPTION
On Obsidian iso's, os-release for Name and ID are obsidianos and obsidian, there is no ID_LIKE. This change enables the detection on obsidian iso's aside the actual distro (arch, gentoo etc.). 