### PR TITLE
fix: openrc-shutdown immediate reboot and expand Gentoo tmpfs to 80%

### DIFF
--- a/obsidian-wizard.py
+++ b/obsidian-wizard.py
@@ -1131,7 +1131,7 @@ def reboot_system():
         ],
     ):
         if shutil.which("openrc-shutdown"):
-            run_command("sudo openrc-shutdown -r 5", "Rebooting system")
+            run_command("sudo openrc-shutdown -r now", "Rebooting system")
         else:    
             run_command("sudo reboot", "Rebooting system")
 
@@ -1202,7 +1202,7 @@ if __name__ == "__main__":
         try:
             clear_screen()
             run_command(
-                "mount -o remount,size=75% /tmp", "Resizing /tmp tmpfs..."
+                "mount -o remount,size=80% /tmp", "Resizing /tmp tmpfs..."
             )
             open("/etc/obsidian-wizard-resized", "w").close()
         except (KeyboardInterrupt, SystemExit):


### PR DESCRIPTION
Picks up the two remaining changes from NitinC09's PR #14 that weren't yet in upstream:
- openrc-shutdown -r now instead of -r 5 (avoids 5-minute wait)
- /tmp tmpfs resize from 75% to 80% for Gentoo ISO builds